### PR TITLE
dumper: Fix androidfilehost mirror station download

### DIFF
--- a/dumper.sh
+++ b/dumper.sh
@@ -152,7 +152,13 @@ else
 		if echo "${URL}" | grep -q "mega.nz\|mediafire.com\|drive.google.com"; then
 			( "${MEGAMEDIADRIVE_DL}" "${URL}" ) || exit 1
 		elif echo "${URL}" | grep -q "androidfilehost.com"; then
-			( python3 "${AFHDL}" -l "${URL}" ) || exit 1
+			if echo "${URL}" | grep -q ".androidfilehost.com"; then
+				aria2c -x16 -s8 --console-log-level=warn --summary-interval=0 --check-certificate=false "${URL}" || {
+					wget -q --show-progress --progress=bar:force --no-check-certificate "${URL}" || exit 1
+				}
+			else
+				( python3 "${AFHDL}" -l "${URL}" ) || exit 1
+			fi
 		else
 			if echo "${URL}" | grep -q "1drv.ms"; then URL=${URL/ms/ws}; fi
 			aria2c -x16 -s8 --console-log-level=warn --summary-interval=0 --check-certificate=false "${URL}" || {


### PR DESCRIPTION
Before this commit, any androidfilehost.com mirror station download link are not support download because of python script not support mirror.  
Error message: This does not appear to be a supported link.

After this commit, if it's mirror station link, it don't will use python script to download.

mirror station link eg. https://ava1.androidfilehost.com/